### PR TITLE
Fixes saving (loading) for docs with videos

### DIFF
--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -115,7 +115,7 @@ class Normalizer
   @pullBlocks: (lineNode) ->
     curNode = lineNode.firstChild
     while curNode?
-      if dom.BLOCK_TAGS[curNode.tagName]? and curNode.tagName != 'LI'
+      if dom.BLOCK_TAGS[curNode.tagName]? and curNode.tagName != 'LI' and curNode.tagName != 'IFRAME'
         dom(curNode).isolate(lineNode.parentNode)
         if (!dom.LIST_TAGS[curNode.tagName]? or !curNode.firstChild) and curNode.tagName != 'IFRAME'
           dom(curNode).unwrap()


### PR DESCRIPTION
I've been having issues where the videos I add would be removed if I save the document multiple times. So anytime I edit a topic in DemocracyOS (with videos) - the videos would fall out :confused: 

Looking at the output from `this.editor.getHTML` in `richtext.js` (in the DemocracyOS codebase) I noticed that the `<div data-section-id>...</div>` around the `iframe` tag was being removed during `setHtml`.

I added this debug code:

``` js
let html = this.input.val();
console.log(html)
this.editor.setHTML(html);
log('Quill object was initialized with the following HTML: %s', html);
setTimeout(function() { console.log(this.editor.getHTML()) }.bind(this),1000)
```

The first output is:

``` html
<div data-section-id="5721ea2438a6bb464a4b5c05">Test med en video...    adasd </div>
<div data-section-id="5721f951fa28baf823016d82"><br></div>
<div data-section-id="5721fb30fa28baf823016d86">
  <iframe src="https://www.youtube.com/embed/2ZF4N8ThPvs">!</iframe>
</div>
<div data-section-id="5721fb30fa28baf823016d87"><br></div>
<div data-section-id="5721f951fa28baf823016d84">esd </div>
```

The second output is:

``` html
<div data-section-id="5721ea2438a6bb464a4b5c05">Test med en video...    adasd</div>
<div data-section-id="5721f951fa28baf823016d82"><br></div>
<iframe src="https://www.youtube.com/embed/2ZF4N8ThPvs">!</iframe>
<div data-section-id="5721fb30fa28baf823016d87"><br></div>
<div data-section-id="5721f951fa28baf823016d84">esd </div>
```

And saving this second output drops the video. So the `setHtml` removes this `div` somewhere. After quite a bit of debugging I found the origin is `Normalizer.pullBlocks` function. Adding the `&& curNode.tagName !== 'IFRAME'` check pr. this PR fixes it for me. But I won't pretend I understand 100% the implications of this change. The quills codebase is quite extensive :stuck_out_tongue_closed_eyes: 

What do you think?
